### PR TITLE
Fixes redundant whitespace at the bottom

### DIFF
--- a/app/scss/_globals.scss
+++ b/app/scss/_globals.scss
@@ -15,7 +15,6 @@ body {
   font-weight: 300;
   color: $grayishBlue;
   line-height: 1.3;
-  min-height: 350vh;
   overflow-x: hidden;
 
   @include breakpoint-up(large){


### PR DESCRIPTION
Maybe I'm wrong, but I think removing the min-height removes the extra whitespace at the bottom of the page. As far as I can tell it doesn't break anything else!